### PR TITLE
Refactor website pattern auth

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -26,6 +26,11 @@ resource "aws_cloudfront_distribution" "this" {
       origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }
+
+    custom_header {
+      name  = "Referer"
+      value = random_uuid.referer.result
+    }
   }
 
   dynamic "origin" {


### PR DESCRIPTION
Changing the overall approach to use the S3 bucket as website and allow only the CloudFront distribution access via the referer header.