### PR TITLE
Full day default TTL. Don't cache 500s

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -10,7 +10,13 @@ locals {
         response_page_path    = "/${var.index_document}"
       }
     ] : [],
-    var.custom_error_response
+    var.custom_error_response,
+    [      
+      {
+        error_caching_min_ttl = 0
+        error_code            = 500
+      }
+    ]
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -80,19 +80,19 @@ variable "forward_query_string" {
 variable "min_ttl" {
   type        = number
   description = "Minimum TTL of cached objects"
-  default     = 0
+  default     = 86400
 }
 
 variable "default_ttl" {
   type        = number
   description = "Default TTL of cached objects"
-  default     = 300
+  default     = 86400
 }
 
 variable "max_ttl" {
   type        = number
   description = "Maximum TTL of cached objects"
-  default     = 3600
+  default     = 86400
 }
 
 variable "cloudfront_price_class" {


### PR DESCRIPTION
Longer cache times. Static deploys are expected to invalidate their cache to prevent mixed age artifacts.

Don't cache 500s.