### PR TITLE
Constrain aws provider to ~> 2.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    aws = "~> 2.0"
+  }
+}


### PR DESCRIPTION
AWS provider >=3.0 has removed the `region` field in `aws_s3_bucket`, instead inferring it from provider used to create the bucket. In order to prevent problems with resource recreation and broken deployments, we are capping the provider to 2.x. 

The next version of this module will require providers >= 3.0 and Terraform >= 0.13.0

Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket