### PR TITLE
Update to TF 0.13.x

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,6 @@ resource "aws_s3_bucket" "this" {
   // checkov:skip=CKV_AWS_52: AWS+TF do not properly support mfa_delete
   bucket = var.bucket_name
   acl    = "private"
-  region = coalesce(var.region, data.aws_region.current.name)
 
   versioning {
     enabled = var.bucket_versioning

--- a/variables.tf
+++ b/variables.tf
@@ -140,9 +140,3 @@ variable "proxies" {
   description = "Paths to proxies and their destinations, no wildcards"
   default     = []
 }
-
-variable "region" {
-  type        = string
-  description = "AWS Region"
-  default     = ""
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,12 @@
 terraform {
   required_providers {
-    aws = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
   }
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
# Update to TF 0.13.x and AWS provider 3.x

This is a potentially backwards incompatible upgrade, so consumers updating from the previous major version should take note before upgrading.

## What's new?
The major update here is that the AWS provider [has now made the region attribute read-only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket) in major version 3. Previously, the bucket and the rest of the resouces could be created in different regions. In the new module, everything should be created in `us-east-1` with the additional provider (see README and examples). This will be a breaking change for users with buckets outside of `us-east-1`.
